### PR TITLE
Return Interceptor listeners to the caller

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,6 +434,6 @@ class Session {
   stop () {
     this.listeners.forEach(listener => {
       listener.detach();
-    })
+    });
   }
 }

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function trace (spec) {
   }
   return {
     stop() {
-      listeners.forEach((listener) => {
+      listeners.forEach(listener => {
         listener.detach();
       })
     }

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function trace (spec) {
     throw new Error('Either a module or a vtable must be specified');
   }
   return {
-    stop: function() {
+    stop() {
       listeners.forEach((listener) => {
         listener.detach();
       })

--- a/index.js
+++ b/index.js
@@ -432,7 +432,7 @@ class Session {
   }
 
   stop () {
-    this.listeners.forEach(listener => {
+    this._listeners.forEach(listener => {
       listener.detach();
     });
   }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function trace (spec) {
     stop() {
       listeners.forEach(listener => {
         listener.detach();
-      })
+      });
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -51,13 +51,7 @@ function trace (spec) {
   } else {
     throw new Error('Either a module or a vtable must be specified');
   }
-  return {
-    stop() {
-      listeners.forEach(listener => {
-        listener.detach();
-      });
-    }
-  };
+  return new Session(listeners);
 }
 
 trace.func = func;
@@ -428,5 +422,17 @@ class Event {
     } else {
       this.args[key] = value;
     }
+  }
+}
+
+class Session {
+  constructor (listeners) {
+    this.listeners = listeners;
+  }
+
+  stop() {
+    this.listeners.forEach(listener => {
+      listener.detach();
+    })
   }
 }

--- a/index.js
+++ b/index.js
@@ -431,7 +431,7 @@ class Session {
     this._listeners = listeners;
   }
 
-  stop() {
+  stop () {
     this.listeners.forEach(listener => {
       listener.detach();
     })

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = trace;
 function trace (spec) {
   const {module, vtable, functions} = spec;
   const {onError} = spec.callbacks;
-  
+
   let listeners = {}; 
   const intercept = makeInterceptor(spec);
 
@@ -105,7 +105,7 @@ function makeInterceptor (spec) {
     const numInputActions = inputActions.length;
     const numOutputActions = outputActions.length;
 
-    const listener = Interceptor.attach(impl, {
+    return Interceptor.attach(impl, {
       onEnter (args) {
         const values = [];
         for (let i = 0; i !== numArgs; i++) {
@@ -141,7 +141,6 @@ function makeInterceptor (spec) {
         onEvent(event);
       }
     });
-    return listener;
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function trace (spec) {
   const {module, vtable, functions} = spec;
   const {onError} = spec.callbacks;
 
-  let listeners = {}; 
+  let listeners = Array();
   const intercept = makeInterceptor(spec);
 
   if (module !== undefined) {
@@ -23,7 +23,7 @@ function trace (spec) {
         return;
       }
 
-      listeners[name] = intercept(func, impl);
+      listeners.push(intercept(func, impl));
     });
   } else if (vtable !== undefined) {
     let offset = 0;
@@ -44,14 +44,20 @@ function trace (spec) {
         break;
       }
 
-      listeners[entry.toString()] = intercept(entry, impl);
+      listeners.push(intercept(entry, impl));
 
       offset += pointerSize;
     }
   } else {
     throw new Error('Either a module or a vtable must be specified');
   }
-  return listeners;
+  return {
+    stop: function() {
+      listeners.forEach((listener) => {
+        listener.detach();
+      })
+    }
+  };
 }
 
 trace.func = func;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function trace (spec) {
   const {module, vtable, functions} = spec;
   const {onError} = spec.callbacks;
 
-  let listeners = Array();
+  const listeners = [];
   const intercept = makeInterceptor(spec);
 
   if (module !== undefined) {

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function trace (spec) {
   } else {
     throw new Error('Either a module or a vtable must be specified');
   }
+  
   return new Session(listeners);
 }
 

--- a/index.js
+++ b/index.js
@@ -23,8 +23,7 @@ function trace (spec) {
         return;
       }
 
-      const listener = intercept(func, impl);
-      listeners[name] = listener;
+      listeners[name] = intercept(func, impl);
     });
   } else if (vtable !== undefined) {
     let offset = 0;
@@ -45,8 +44,7 @@ function trace (spec) {
         break;
       }
 
-      const listener = intercept(entry, impl);
-      listeners[entry.toString()] = listener;
+      listeners[entry.toString()] = intercept(entry, impl);
 
       offset += pointerSize;
     }

--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ class Event {
 
 class Session {
   constructor (listeners) {
-    this.listeners = listeners;
+    this._listeners = listeners;
   }
 
   stop() {


### PR DESCRIPTION
Addresses #13.

At first, I thought an array of listeners would be enough, at least it is for my use-case. But perhaps there is a wider desire to have some context around the listeners returned, so I decided to return a dictionary. Let me know if you prefer this done another way.
Not convinced I'm handling the vtable stuff in a sensible way either.

Otherwise, this should be a trivial change.
