### PR TITLE
Add optional shouldSkip() callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ trace.types = {
 };
 
 function makeInterceptor (spec) {
-  const {onEvent, onEnter, onLeave, onError} = spec.callbacks;
+  const {shouldSkip, onEvent, onEnter, onLeave, onError} = spec.callbacks;
 
   return function (func, impl) {
     const name = func.name;
@@ -106,6 +106,10 @@ function makeInterceptor (spec) {
 
     return Interceptor.attach(impl, {
       onEnter (args) {
+        if (shouldSkip !== undefined && shouldSkip.call(this)) {
+          this._skip = true;
+          return;
+        }
         const values = [];
         for (let i = 0; i !== numArgs; i++) {
           values.push(args[i]);
@@ -124,6 +128,9 @@ function makeInterceptor (spec) {
         this.event = event;
       },
       onLeave (retval) {
+        if (this._skip === true) {
+          return;
+        }
         const values = this.values;
         const event = this.event;
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function makeInterceptor (spec) {
 
     return Interceptor.attach(impl, {
       onEnter (args) {
-        if (shouldSkip !== undefined && shouldSkip.call(this)) {
+        if (shouldSkip?.(this)) {
           this._skip = true;
           return;
         }


### PR DESCRIPTION
The invocation context passed as `this` can be used by the optional `shouldSkip()` callback to decide if the tracing of the specific hook should be skipped.

If it returns `true` no other work is performed for the invocation, including handling of arguments, and the `Interceptor` callbacks can return early to maximize performance and minimize the risk of stability issues.